### PR TITLE
Fix path for all files

### DIFF
--- a/edge_detection/cannyExample.py
+++ b/edge_detection/cannyExample.py
@@ -1,8 +1,10 @@
 import cv2 as cv
 import numpy as np
 import os 
+import sys
 
-path = os.path.join('..', os.getcwd(), 'images', 'm1a2_abrams_l5.jpg')
+script_path = os.path.abspath(sys.argv[0])
+path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', 'images', 'm1a2_abrams_l5.jpg'))
 image = cv.imread(path)
 cv.imshow('Original', image)
 # Read the image

--- a/edge_detection/edgeDetection.py
+++ b/edge_detection/edgeDetection.py
@@ -1,9 +1,11 @@
 import cv2 as cv
 import numpy as np
 import os
+import sys
 
 def main():
-    path = os.path.join('..', os.getcwd(), 'images', 'm1a2_abrams_l5.jpg')
+    script_path = os.path.abspath(sys.argv[0])
+    path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', 'images', 'm1a2_abrams_l5.jpg'))
     img = cv.imread(path)
     cv.imshow('Original', img)
 

--- a/frequency_filtering/high_pass/BHPF.py
+++ b/frequency_filtering/high_pass/BHPF.py
@@ -10,7 +10,8 @@ sys.path.append(os.path.dirname(SCRIPT_DIR))
 import filter_utilities as utils
 
 def main():
-    path = os.path.join('..', os.getcwd(), 'images', 'lena.jpg')
+    script_path = os.path.abspath(sys.argv[0])
+    path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', '..', 'images', 'lena.jpg'))
     imgGray  = cv.imread(path, flags=0) # flags=0 to import as grrayscale
     rows, cols = imgGray.shape[:2]  # The height and width of the picture
     plt.figure(figsize=(10, 6))

--- a/frequency_filtering/high_pass/GHPF.py
+++ b/frequency_filtering/high_pass/GHPF.py
@@ -10,7 +10,8 @@ sys.path.append(os.path.dirname(SCRIPT_DIR))
 import filter_utilities as utils
 
 def main():
-    path = os.path.join('..', os.getcwd(), 'images', 'lena.jpg')
+    script_path = os.path.abspath(sys.argv[0])
+    path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', '..', 'images', 'lena.jpg'))
     imgGray  = cv.imread(path, flags=0) # flags=0 to import as grrayscale
     rows, cols = imgGray.shape[:2]  # The height and width of the picture
     plt.figure(figsize=(10, 6))

--- a/frequency_filtering/high_pass/IHPF.py
+++ b/frequency_filtering/high_pass/IHPF.py
@@ -10,7 +10,8 @@ sys.path.append(os.path.dirname(SCRIPT_DIR))
 import filter_utilities as utils
 
 def main():
-    path = os.path.join('..', os.getcwd(), 'images', 'lena.jpg')
+    script_path = os.path.abspath(sys.argv[0])
+    path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', '..', 'images', 'lena.jpg'))
     imgGray  = cv.imread(path, flags=0) # flags=0 to import as grrayscale
     rows, cols = imgGray.shape[:2]  # The height and width of the picture
     plt.figure(figsize=(10, 6))

--- a/frequency_filtering/low_pass/BLP.py
+++ b/frequency_filtering/low_pass/BLP.py
@@ -10,7 +10,8 @@ sys.path.append(os.path.dirname(SCRIPT_DIR))
 import filter_utilities as utils
 
 def main():
-    path = os.path.join('..', os.getcwd(), 'images', 'lena.jpg')
+    script_path = os.path.abspath(sys.argv[0])
+    path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', '..', 'images', 'lena.jpg'))
     imgGray  = cv.imread(path, flags=0) # flags=0 to import as grrayscale
     rows, cols = imgGray.shape[:2]  # The height and width of the picture
     plt.figure(figsize=(10, 6))

--- a/frequency_filtering/low_pass/GLP.py
+++ b/frequency_filtering/low_pass/GLP.py
@@ -4,13 +4,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 import sys
 
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.dirname(SCRIPT_DIR))
-
-import filter_utilities as utils
-
 def main():
-    path = os.path.join('..', os.getcwd(), 'images', 'lena.jpg')
+    script_path = os.path.abspath(sys.argv[0])
+    path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', '..', 'images', 'lena.jpg'))
     imgGray  = cv.imread(path, flags=0) # flags=0 to import as grrayscale
     f = np.fft.fft2(imgGray)
     f_shift = np.fft.fftshift(f)

--- a/frequency_filtering/pass_band/BBPF.py
+++ b/frequency_filtering/pass_band/BBPF.py
@@ -10,7 +10,8 @@ sys.path.append(os.path.dirname(SCRIPT_DIR))
 import filter_utilities as utils
 
 def main():
-    path = os.path.join('..', os.getcwd(), 'images', 'lena.jpg')
+    script_path = os.path.abspath(sys.argv[0])
+    path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', '..', 'images', 'lena.jpg'))
     imgGray  = cv.imread(path, flags=0) # flags=0 to import as grrayscale
     rows, cols = imgGray.shape[:2]  # The height and width of the picture
 

--- a/frequency_filtering/pass_band/GBPF.py
+++ b/frequency_filtering/pass_band/GBPF.py
@@ -10,7 +10,8 @@ sys.path.append(os.path.dirname(SCRIPT_DIR))
 import filter_utilities as utils
 
 def main():
-    path = os.path.join('..', os.getcwd(), 'images', 'lena.jpg')
+    script_path = os.path.abspath(sys.argv[0])
+    path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', '..', 'images', 'lena.jpg'))
     imgGray  = cv.imread(path, flags=0) # flags=0 to import as grrayscale
     rows, cols = imgGray.shape[:2]  # The height and width of the picture
 

--- a/frequency_filtering/pass_band/IBPF.py
+++ b/frequency_filtering/pass_band/IBPF.py
@@ -10,7 +10,8 @@ sys.path.append(os.path.dirname(SCRIPT_DIR))
 import filter_utilities as utils
 
 def main():
-    path = os.path.join('..', os.getcwd(), 'images', 'lena.jpg')
+    script_path = os.path.abspath(sys.argv[0])
+    path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', '..', 'images', 'lena.jpg'))
     imgGray  = cv.imread(path, flags=0) # flags=0 to import as grrayscale
     rows, cols = imgGray.shape[:2]  # The height and width of the picture
 

--- a/histograms_and_thresholding/binarization.py
+++ b/histograms_and_thresholding/binarization.py
@@ -2,9 +2,11 @@ import cv2 as cv
 import numpy as np
 from matplotlib import pyplot as plt
 import os
+import sys
 
 def main():
-    path = os.path.join('..', os.getcwd(), 'images', 'lena.jpg')
+    script_path = os.path.abspath(sys.argv[0])
+    path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', 'images', 'lena.jpg'))
     img = cv.imread(path, cv.IMREAD_GRAYSCALE)
     assert img is not None, "file could not be read, check with os.path.exists()"
     # global thresholding

--- a/histograms_and_thresholding/histograms.py
+++ b/histograms_and_thresholding/histograms.py
@@ -1,9 +1,11 @@
 import cv2 as cv
 import matplotlib.pyplot as plt
 import os
+import sys
 
 def main():
-    path = os.path.join('..', os.getcwd(), 'images', 'lena.jpg')
+    script_path = os.path.abspath(sys.argv[0])
+    path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', 'images', 'lena.jpg'))
     img = cv.imread(path)
     #cv.imshow('Original', img)
 

--- a/histograms_and_thresholding/thresh.py
+++ b/histograms_and_thresholding/thresh.py
@@ -3,9 +3,11 @@ from cv2 import threshold
 import matplotlib.pyplot as plt
 from numpy import histogram
 import os
+import sys 
 
 def main():
-    path = os.path.join('..', os.getcwd(), 'images', 'lena.jpg')
+    script_path = os.path.abspath(sys.argv[0])
+    path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', 'images', 'lena.jpg'))
     img = cv.imread(path)
 
     cv.imshow('Original', img)

--- a/image_restoration/Wiener_Filter.py
+++ b/image_restoration/Wiener_Filter.py
@@ -44,7 +44,8 @@ def rgb2gray(rgb):
 
 if __name__ == '__main__':
 	# Load image and convert it to gray scale
-    path = os.path.join('..', os.getcwd(), 'images', 'lena.jpg')
+    script_path = os.path.abspath(sys.argv[0])
+    path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', 'images', 'lena.jpg'))
     img = rgb2gray(plt.imread(path))
 
     # Blur the image

--- a/image_restoration/comparison.py
+++ b/image_restoration/comparison.py
@@ -10,9 +10,10 @@ sys.path.append(os.path.dirname(SCRIPT_DIR))
 
 if __name__ == '__main__':
 	# Load image and convert it to gray scale
-    file_name = os.path.join('..', os.getcwd(), 'images', 'lena.jpg')
+    script_path = os.path.abspath(sys.argv[0])
+    path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', 'images', 'lena.jpg'))
 
-    img = cv.imread(file_name)
+    img = cv.imread(path)
     img = cv.cvtColor(img, cv.COLOR_BGR2GRAY)
 	# Blur image
     blurred_img = blur(img, kernel_size = 9)

--- a/image_segmentation/coins.py
+++ b/image_segmentation/coins.py
@@ -2,9 +2,11 @@ import os
 import numpy as np
 import cv2 as cv
 from matplotlib import pyplot as plt
+import sys
 
 def main():
-    path = os.path.join('..', os.getcwd(), 'images', 'coins.jpg')
+    script_path = os.path.abspath(sys.argv[0])
+    path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', 'images', 'coins.jpg'))
     img  = cv.imread(path)
     gray = cv.cvtColor(img,cv.COLOR_BGR2GRAY)
     ret, thresh = cv.threshold(gray,0,255,cv.THRESH_BINARY_INV+cv.THRESH_OTSU)

--- a/image_segmentation/contours.py
+++ b/image_segmentation/contours.py
@@ -1,9 +1,11 @@
 import numpy as np
 import cv2 as cv
 import os
+import sys
 
 def main():
-    path = os.path.join('..', os.getcwd(), 'images', 'squares.png')
+    script_path = os.path.abspath(sys.argv[0])
+    path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', 'images', 'squares.jpg'))
     image  = cv.imread(path)
     cv.imshow('input image', image)
     cv.waitKey(0)

--- a/image_segmentation/convex_hull.py
+++ b/image_segmentation/convex_hull.py
@@ -2,9 +2,11 @@ from operator import countOf
 import numpy as np
 import cv2 as cv
 import os
+import sys
 
 def main():
-    path = os.path.join('..', os.getcwd(), 'images', 'house.jpg')
+    script_path = os.path.abspath(sys.argv[0])
+    path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', 'images', 'house.jpg'))
     image  = cv.imread(path)
     orig_image=image.copy()
     cv.imshow('original image',orig_image)

--- a/image_segmentation/watershed.py
+++ b/image_segmentation/watershed.py
@@ -2,11 +2,11 @@ import cv2 as cv
 import os
 from matplotlib import pyplot as plt
 import numpy as np
+import sys
 
 def main():
-
-
-    path = os.path.join('..', os.getcwd(), 'images', 'coins.jpg')
+    script_path = os.path.abspath(sys.argv[0])
+    path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', 'images', 'coins.jpg'))
     img = cv.imread(path)
     gray = cv.cvtColor(img,cv.COLOR_BGR2GRAY)
     ret, thresh = cv.threshold(gray,0,255,cv.THRESH_BINARY_INV+cv.THRESH_OTSU)

--- a/morphological_processing/boundary_extraction.py
+++ b/morphological_processing/boundary_extraction.py
@@ -3,9 +3,11 @@ import cv2 as cv
 import os
 import numpy as np
 import matplotlib.pyplot as plt
+import sys
 
 def main():
-    path = os.path.join('..', os.getcwd(), 'images', 'coins.jpg')
+    script_path = os.path.abspath(sys.argv[0])
+    path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', 'images', 'coins.jpg'))
     img  = cv.imread(path) # flag 0 for grayscale image
     gray = cv.cvtColor(img, cv.COLOR_BGR2GRAY)
     # Read the image as a grayscale image

--- a/morphological_processing/morphological_operatioins.py
+++ b/morphological_processing/morphological_operatioins.py
@@ -2,9 +2,11 @@ import os
 import cv2 as cv
 import numpy as np
 import matplotlib.pyplot as plt
+import sys
 
 def main():
-    path = os.path.join('..', os.getcwd(), 'images', 'coins.jpg')
+    script_path = os.path.abspath(sys.argv[0])
+    path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', 'images', 'coins.jpg'))
     img  = cv.imread(path, flags=0) # flag 0 for grayscale image
     ret, thresh = cv.threshold(img, 100, 255, cv.THRESH_BINARY_INV)
     #thresh = cv.adaptiveThreshold(img, 255, cv.ADAPTIVE_THRESH_MEAN_C, cv.THRESH_BINARY, 11, 3)

--- a/morphological_processing/morphological_skeleton.py
+++ b/morphological_processing/morphological_skeleton.py
@@ -3,9 +3,11 @@ import cv2 as cv
 import os
 import numpy as np
 import matplotlib.pyplot as plt
+import sys
 
 def main():
-    path = os.path.join('..', os.getcwd(), 'images', 'coins.jpg')
+    script_path = os.path.abspath(sys.argv[0])
+    path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', 'images', 'coins.jpg'))
     img  = cv.imread(path, flags=0) # flag 0 for grayscale image
     # Read the image as a grayscale image
     cv.imshow('image', img)

--- a/space_filters/blurring.py
+++ b/space_filters/blurring.py
@@ -1,6 +1,7 @@
 import cv2 as cv
 import os
 import numpy as np
+import sys
 
 def noisy(noise_typ,image):
    if noise_typ == "gauss":
@@ -42,7 +43,8 @@ def noisy(noise_typ,image):
       return noisy
 
 def main():
-    path = os.path.join('..', os.getcwd(), 'images', 'lena.jpg')
+    script_path = os.path.abspath(sys.argv[0])
+    path = os.path.abspath(os.path.join(os.path.dirname(script_path), '..', 'images', 'lena.jpg'))
     img = cv.imread(path)
     noisy_gauss_img = noisy("gauss", img)
     noisy_salt_pepper_img = noisy("s&p", img)


### PR DESCRIPTION
- All images are located in `images` folder
- All images were read from this folder using a ```getcwd()``` function whose output depends from where the file is run from. 
- This was a bad practice because a program should not crash depending on folder it was run from. 
- New implementation finds the absolute path of the python file and goes back one or two folder to find `images` folder.